### PR TITLE
Implemented openAI to generate job opportunities

### DIFF
--- a/Frontend/src/components/JobQuickSearchCard.jsx
+++ b/Frontend/src/components/JobQuickSearchCard.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Box, Card, CardContent, Typography, TextField, MenuItem, Button, CircularProgress } from '@mui/material';
+import axios from 'axios';
+
+const experienceOptions = ['Entry Level', 'Mid Level', 'Senior Level'];
+const jobTypeOptions = ['Full-Time', 'Part-Time'];
+
+const JobQuickSearchCard = ({ onResults }) => {
+  const [form, setForm] = useState({
+    role: '',
+    experience: '',
+    location: '',
+    salary: '',
+    jobType: '',
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSearch = async () => {
+    setLoading(true);
+    try {
+      const res = await axios.post('/api/job-search', form);
+      onResults(res.data.jobs);
+    } catch (error) {
+      onResults('Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card sx={{ p: 2, mb: 2, mt: 8 }}>
+      <CardContent>
+        <Typography variant="h6" gutterBottom sx={{ textAlign: 'center', mb: 4, color: '#4C8285', fontWeight: 'bold',
+         }}>
+          AI-Powered Job Search
+        </Typography>
+
+        <Box display="flex" flexDirection="column" gap={4}>
+          <TextField label="Job Role" name="role" value={form.role} onChange={handleChange} fullWidth />
+          <TextField label="Location" name="location" value={form.location} onChange={handleChange} fullWidth />
+          <TextField label="Salary Expectation" name="salary" value={form.salary} onChange={handleChange} fullWidth />
+
+          <TextField select label="Experience Level" name="experience" value={form.experience} onChange={handleChange} fullWidth>
+            {experienceOptions.map((level) => (
+              <MenuItem key={level} value={level}>{level}</MenuItem>
+            ))}
+          </TextField>
+
+          <TextField select label="Job Type" name="jobType" value={form.jobType} onChange={handleChange} fullWidth>
+            {jobTypeOptions.map((type) => (
+              <MenuItem key={type} value={type}>{type}</MenuItem>
+            ))}
+          </TextField>
+
+          <Button variant="contained" onClick={handleSearch} disabled={loading} sx={{ backgroundColor: '#4C8285' }} >
+            {loading ? <CircularProgress size={24} /> : 'Search Jobs'}
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default JobQuickSearchCard;

--- a/Frontend/src/pages/JobTracker.jsx
+++ b/Frontend/src/pages/JobTracker.jsx
@@ -13,6 +13,7 @@ import AddIcon from '@mui/icons-material/Add';
 import api from '../api/apiClient';
 import JobCard from '../components/JobCard';
 import JobDialog from '../components/JobDialog';
+import JobQuickSearchCard from '../components/JobQuickSearchCard';
 
 const JobTracker = () => {
   const [open, setOpen] = useState(false);
@@ -30,6 +31,7 @@ const JobTracker = () => {
   const [error, setError] = useState('');
 
   const [filterStatus, setFilterStatus] = useState('All');
+  const [aiResults, setAiResults] = useState([]);
 
   const resetForm = () => {
     setCompany('');
@@ -57,11 +59,11 @@ const JobTracker = () => {
   }, []);
 
   const handleSave = async () => {
-      if (!skills || skills.length === 0) {
-         // ADD this to check for empty skills
-         setError("Please enter at least one skill");
-         return;
-      }
+    if (!skills || skills.length === 0) {
+      // ADD this to check for empty skills
+      setError("Please enter at least one skill");
+      return;
+    }
     const jobPayload = {
       company,
       role,
@@ -211,6 +213,51 @@ const JobTracker = () => {
                 </Grid>
               ))}
           </Grid>
+        </Box>
+
+        {/* AI Job Quick Search Section */}
+        <Box sx={{ backgroundColor: '#e6f0ee', borderRadius: 3, px: 4, py: 6, boxShadow: 1, mt: 6 }}>
+          <Box display="flex" flexDirection={{ xs: 'column', md: 'row' }} gap={4}>
+            <Box flex={1}>
+              <JobQuickSearchCard onResults={setAiResults} />
+            </Box>
+            <Box flex={2}>
+              <Typography variant="h6" sx={{ mb: 2, color: '#4C8285', fontWeight: 'bold', fontSize: 30, textAlign: 'center' }}>
+                AI-Recommended Jobs
+              </Typography>
+              <Box sx={{ backgroundColor: '#fff', borderRadius: 2, p: 2, minHeight: 200 }}>
+              {Array.isArray(aiResults) && aiResults.length > 0 ? (
+                aiResults.map((job, i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      mb: 3,
+                      p: 2,
+                      border: '1px solid #ddd',
+                      borderRadius: 2,
+                      backgroundColor: '#f9f9f9',
+                    }}
+                  >
+                    <Typography variant="subtitle1" fontWeight="bold" sx={{ color: '#4C8285' }}>
+                      {job.title}
+                    </Typography>
+                    <Typography variant="body2" sx={{ mt: 0.5 }}>
+                      <strong>Company:</strong> {job.company}
+                    </Typography>
+                    <Typography variant="body2">
+                      <strong>Location:</strong> {job.location}
+                    </Typography>
+                    <Typography variant="body2" sx={{ mt: 1 }}>
+                      {job.summary}
+                    </Typography>
+                  </Box>
+                ))
+              ) : (
+                <Typography color="text.secondary">No results yet. Complete the AI-Powered Job Search form and AI will provide you with relevant job opportunities.</Typography>
+              )}
+              </Box>
+            </Box>
+          </Box>
         </Box>
       </Container>
 

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     // Proxy /api calls to your Express backend on port 5000
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://localhost:5007',
         changeOrigin: true,
         secure: false
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,7 +193,8 @@
         "is-symbol": "^1.1.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.13.2",
-        "multer": "^2.0.0"
+        "multer": "^2.0.0",
+        "openai": "^5.0.1"
       },
       "devDependencies": {
         "eslint-plugin-react-hooks": "^4.6.2"
@@ -3957,6 +3958,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.0.1.tgz",
+      "integrity": "sha512-Do6vxhbDv7cXhji/4ct1lrpZYMAOmjYbhyA9LJTuG7OfpbWMpuS+EIXkRT7R+XxpRB1OZhU/op4FU3p3uxU6gw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -191,7 +191,8 @@
     "is-symbol": "^1.1.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.13.2",
-    "multer": "^2.0.0"
+    "multer": "^2.0.0",
+    "openai": "^5.0.1"
   },
   "scripts": {
     "start:server": "node server/index.js",

--- a/server/controllers/jobSearchController.js
+++ b/server/controllers/jobSearchController.js
@@ -1,0 +1,54 @@
+const OpenAI = require('openai');
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const fetchJobsFromAI = async (req, res) => {
+  const { role, experience, location, salary, jobType } = req.body;
+
+  const prompt = `You are an expert job matching assistant. Return exactly 5 real job listings in JSON format, based on the following preferences:
+  Role: ${role}
+  Experience Level: ${experience}
+  Location: ${location}
+  Salary Expectation: ${salary}
+  Job Type: ${jobType}
+
+  Return only a JSON array of 5 jobs. Each job should have the following fields:
+  - title (string)
+  - company (string)
+  - location (string)
+  - summary (string)
+
+  Example:
+
+  [
+    {
+      "title": "Software Engineer",
+      "company": "TechCorp",
+      "location": "San Francisco, CA",
+      "summary": "Work on full-stack web applications in a fast-paced environment."
+    },
+    ...
+  ]`;
+
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    let jobs = [];
+
+  try {
+    jobs = JSON.parse(completion.choices[0].message.content);
+  } catch (parseError) {
+    console.error('Failed to parse JSON:', parseError);
+    return res.status(500).json({ error: 'Invalid AI response format' });
+  }
+
+    res.json({ jobs });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Failed to fetch jobs from OpenAI' });
+  }
+};
+
+module.exports = { fetchJobsFromAI };

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const skillRoutes = require('./routes/skillRoutes');
 const userRoutes  = require('./routes/user');
 const jobRoutes   = require('./routes/jobRoutes');
 const contactRoutes = require('./routes/contactRoutes');
+const jobSearchRoutes = require('./routes/jobSearchRoutes');
 
 // ── JWT auth middleware ───────────────────────────────────────────────────────
 const verifyToken = require('./middleware/verifyToken');
@@ -34,6 +35,7 @@ const path = require('path'); // ← Add to your top-level imports if not alread
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 app.use('/api/upload', uploadRoutes);               // Handle image upload requests
+app.use('/api', jobSearchRoutes);
 
 // ── PUBLIC ROUTES ─────────────────────────────────────────────────────────────
 app.get('/', (req, res) => res.send('✅ Job Tracker API is up and running'));
@@ -55,7 +57,7 @@ mongoose
     dbName: 'test'
   })
   .then(() => {
-    const PORT = process.env.PORT || 5000;
+    const PORT = process.env.PORT || 5007;
     app.listen(PORT, () => {
       console.log(`🚀 Server listening on http://localhost:${PORT}`);
     });

--- a/server/routes/jobSearchRoutes.js
+++ b/server/routes/jobSearchRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { fetchJobsFromAI } = require('../controllers/jobSearchController');
+
+const router = express.Router();
+
+router.post('/job-search', fetchJobsFromAI);
+
+module.exports = router;


### PR DESCRIPTION
I implemented use of the openAI API to generate relevant job listings based on user preference. I created a new component called JobQuickSearchCard.jsx which is just a form for the user to fill out their job preferences. The jobSearchController calls the openAI API and provides a detailed prompt that includes the user's job preference info, and asks AI to display the results in a JSON format. The JSON is then parsed and cleanly displayed on the Job Tracker page.

This requires an openAI API Key which is NOT free. I have an existing account that I've used previously for hackathons and thought this would be fun to integrate using my leftover balance (about $5). My account is charged every time the API is called, but the model I chose is extremely cheap (gpt-3.5-turbo) and $5 will last a long long time. Due to choosing a cheaper model that only returns text and not web results, the results are fictional, but they serve as a wonderful placeholder for the future. If we wanted the results to be accurate and provide a link to the website it was scraped from, we would just need to change the model to one that supports web search, and adjust the prompt to have AI return real-time results. I've provided a screenshot of the models that support Web Search and their prices per 1000 calls, just for reference.

https://platform.openai.com/docs/pricing

<img width="865" alt="image" src="https://github.com/user-attachments/assets/b769e6c1-6fa3-41e5-bdfb-fd9719338c59" />
